### PR TITLE
Simplify build step to prevent creation of lots of containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,24 +5,14 @@ DIR := ${CURDIR}
 build:
 	docker build -t pygmy-go .
 	@echo "Removing binaries from previous build"
-	docker run -v $(DIR):/data pygmy-go rm -f /data/builds/pygmy-go*
+	docker run --rm -v $(DIR):/data pygmy-go sh -c 'rm -f /data/builds/pygmy-go*'
 	@echo "Done"
 	@echo "Copying binaries to build directory"
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-386 /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-386-static /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-arm /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-arm-static /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-arm64 /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-arm64-static /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-amd64 /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-amd64-static /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-darwin-amd64 /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-darwin-arm64 /data/builds/.
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go.exe /data/builds/.
+	docker run --rm -v $(DIR):/data pygmy-go sh -c 'cp pygmy-g* /data/builds/.'
 	@echo "Done"
-	@echo "Enjoy using pygmy-go binaries in $(DIR)/build directory."
+	@echo "Enjoy using pygmy-go binaries in the $(DIR)/build directory."
 
 clean:
 	docker image rm -f pygmy-go
-	docker image prune -f --filter label=stage=builder
+	docker image prune -f --filter="label=stage=builder"
 


### PR DESCRIPTION
Just a small tweak to the build step to avoid creating lots of ephemeral containers, and make copying easier by passing the globs through to the Alpine containers.